### PR TITLE
Python parser fixes

### DIFF
--- a/verain/python/Templates/ASSEMBLIES.py
+++ b/verain/python/Templates/ASSEMBLIES.py
@@ -203,26 +203,29 @@ _assemblyContentDiff = {
           "_name": "gridloss_old",
           "_pltype": "parameter",
           "_type": "double",
+          "_optional": True,
           # "_do":
           #  - copy %ASSEMBLY/$(_path)/%grid/@(_lgrid)"":3
-          "_value": [copy_value, 4],
+          "_value": [copy_value_if_not, '/', 4],
         },
-        # {
-        #   "_name": "gridloss",
-        #   "_pltype": "parameter",
-        #   "_type": "double",
-        #   # "_do":
-        #   #  - copy %ASSEMBLY/$(_path)/%grid/$(_lgrid)^/$loss
-        #   "_value": copy_value,
-        # },
-        # {
-        #   "_name": "gridblock",
-        #   "_pltype": "parameter",
-        #   "_type": "double",
-        #   # "_do":
-        #   #  - copy %ASSEMBLY/$(_path)/%grid/$(_lgrid)^/$blockage
-        #   "_value": copy_value,
-        # }
+        {
+          "_name": "gridloss",
+          "_pltype": "parameter",
+          "_type": "double",
+          "_optional": True,
+          # "_do":
+          #  - copy %ASSEMBLY/$(_path)/%grid/$(_lgrid)^/$loss
+          "_value": [extract_param, "loss"],
+        },
+        {
+          "_name": "gridblock",
+          "_pltype": "parameter",
+          "_type": "double",
+          "_optional": True,
+          # "_do":
+          #  - copy %ASSEMBLY/$(_path)/%grid/$(_lgrid)^/$blockage
+          "_value": [extract_param, "blockage"],
+        }
       ]
     },
 

--- a/verain/python/Templates/CORE.py
+++ b/verain/python/Templates/CORE.py
@@ -533,7 +533,9 @@ CORE = {
           "_pltype": "array",
           "_type": "double",
           "_optional": True,
-          "_value": [copy_array_before_val, '/', slice(3, None, 2)],
+          # almost works, but sometimes we need a default frac
+          # "_value": [copy_array_before_val, '/', slice(3, None, 2)],
+          "_value": mat_fracs,
         },
         {
           "_name": "mat_names",

--- a/verain/python/Templates/Utils.py
+++ b/verain/python/Templates/Utils.py
@@ -93,6 +93,11 @@ def copy_value(toks, index=0):
 def copy_value_mult(toks, index, mult):
   return toks[index] * mult
 
+def copy_value_if_not(toks, exclude, index=0):
+  if toks[index] != exclude:
+    return toks[index]
+  return None
+
 def copy_array(toks, inSlice=slice(0, None)):
   # want a comma-delimited list, surrounded by {}
   # flatten nested lists for multi-line cards
@@ -105,7 +110,7 @@ def copy_array_after_val(toks, val, inSlice=slice(0, None)):
     # grab the list after the first val we found.
     outList = outList[indices[0]+1:]
     return copy_array(outList, inSlice)
-  return ""
+  return None
 
 def copy_array_before_val(toks, val, inSlice=slice(0, None)):
   outList = flatten(toks)
@@ -294,3 +299,19 @@ def extract_core_shape(toks):
 
   totalOnes = reduce(lambda x, y: x+y, onesPerRow, 0)
   return (totalOnes, onesPerRow)
+
+# almost: [copy_array_before_val, '/', slice(3, None, 2)],
+# but we need a default of 1 if there's a name with no frac.
+def mat_fracs(toks):
+  val = '/'
+  # strip name, density
+  outList = flatten(toks)[2:]
+  indices = [i for i, j in enumerate(outList) if j == val]
+  if indices:
+    # grab the list before the first val we found.
+    outList = outList[:indices[0]]
+  # if there's only a name, the default frac is 1
+  if len(outList) == 1:
+    return copy_array([1])
+  # otherwise copy the second value in each pair.
+  return copy_array(outList, slice(1, None, 2))

--- a/verain/python/inp2xml.py
+++ b/verain/python/inp2xml.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import pyparsing as pp
 import os, argparse
 # import Utils.flatten
+# this requires python 2.7+
+from collections import OrderedDict
 
 from Templates.CASEID import CASEID
 from Templates.STATE import STATE
@@ -410,11 +412,11 @@ class VeraInConverter(object):
     # a section card (like 'axial') causes other section cards to be ignored.
     def outputCards(self, cards, paramDict, useDict=0):
         # Collect cards that appear more than once, to be output together
-        listCards = {}
+        listCards = OrderedDict()
         # collect cards that are unique, but should be output inside a list
-        groupedCards = {}
+        groupedCards = OrderedDict()
         # all other unique cards, custom values over-write defaults
-        cardDict = {}
+        cardDict = OrderedDict()
 
         sectionName = ""
         refs = paramDict["_refs"] if "_refs" in paramDict else None


### PR DESCRIPTION
Fix dictionary ordering for python 2.7

Fix: mat_fracs have a default of 1 if there's only one material
Fix gridloss to new format