### PR TITLE
Recursive includes with relative sub-directories, STATE, MPACT update

### DIFF
--- a/verain/python/Templates/MPACT.py
+++ b/verain/python/Templates/MPACT.py
@@ -170,6 +170,15 @@ MPACT = {
         }
       ]
     },
+    "rst_compress": {
+      "_output": [
+        {
+          "_pltype": "parameter",
+          "_type": "string",
+          "_value": copy_value,
+        }
+      ]
+    },
     "vis_edits": {
       "_output": [
         {

--- a/verain/python/Templates/STATE.py
+++ b/verain/python/Templates/STATE.py
@@ -241,7 +241,7 @@ STATE = {
           "_type": "string",
           # "_do":
           #   - copyarray %STATE/$(_loop)/$edit
-          "_value": copy_value,
+          "_value": copy_array,
         }
       ]
     },
@@ -422,7 +422,7 @@ STATE = {
           "_type": "string",
           # "_do":
           #   - coremapmap CORE/$size,CORE/@core_shape,%STATE/$(_loop)/@shuffle_label,CORE/$bc_sym,expand=>0,ignore=>'-'
-          "_value": copy_value,
+          "_value": [core_map, "ref:size:0", "ref:shape"],
         }
       ]
     },
@@ -433,7 +433,7 @@ STATE = {
           "_type": "double",
           # "_do":
           #   - coremapmap CORE/$size,CORE/@core_shape,%STATE/$(_loop)/@tinlet_dist,CORE/$bc_sym
-          "_value": copy_value,
+          "_value": [core_map, "ref:size:0", "ref:shape"],
         }
       ]
     },
@@ -444,7 +444,7 @@ STATE = {
           "_type": "double",
           # "_do":
           #   - coremapmap CORE/$size,CORE/@core_shape,%STATE/$(_loop)/@void,CORE/$bc_sym
-          "_value": copy_value,
+          "_value": [core_map, "ref:size:0", "ref:shape"],
         }
       ]
     },
@@ -455,7 +455,7 @@ STATE = {
           "_type": "double",
           # "_do":
           #   - coremapmap CORE/$size,CORE/@core_shape,%STATE/$(_loop)/@flow_dist,CORE/$bc_sym
-          "_value": copy_value,
+          "_value": [core_map, "ref:size:0", "ref:shape"],
         }
       ]
     },

--- a/verain/python/Templates/Utils.py
+++ b/verain/python/Templates/Utils.py
@@ -258,6 +258,14 @@ def core_map(toks, coreSize, coreStats, symmetry="rot"):
 
     return copy_array([val] * repeat)
 
+  # first row might be on same line as card name - need to re-org into list
+  if type(toks[0]) is str or type(toks[0]) is int:
+    firstRow = [toks[0]]
+    toks[0] = firstRow
+    for i in range(1, onesPerRow[0]):
+      if type(toks[1]) is str or type(toks[1]) is int:
+        firstRow.append(toks.pop(1))
+
   if coreSize > 1 and len(toks[0]) == 1:
     quad = octToQuadMap(toks)
   else:
@@ -274,6 +282,7 @@ def core_map(toks, coreSize, coreStats, symmetry="rot"):
       raise ValueError("Map row %d inconsistent, expect %d, got %d" % (i, len(full[i]), count))
   return copy_array(full)
 
+# Treat an assembly like a coremap, but it's completely filled in, numPins x numPins.
 def assembly_map(toks, numPins):
   stats = (numPins, [numPins] * numPins)
   return core_map(toks[1:], numPins, stats)


### PR DESCRIPTION
Update to VERA 3.8rc2
Allow recursive includes, where one include file includes another.
Search for includes will start with the current file's directory, so
relative sub-directory includes work.

Fix MPACT, add a param from v3.8
Fix STATE, missed an array copy, and get refs from CORE so
the core-map cards can be handled correctly.