### PR TITLE
Template conversion for Simput

### DIFF
--- a/verain/python/Templates/Utils.py
+++ b/verain/python/Templates/Utils.py
@@ -56,12 +56,12 @@ def quadToFullMap(a, symmetry):
   if symmetry == "rot":
     # drop the first row, which after transposition is a duplicate
     # of the bottom-right's first column
-    bottom_right = transpose(a[:0:-1])
+    bottom_left = transpose(a[:0:-1])
   else:
-    bottom_right = [list(row)[:0:-1] for row in a]
+    bottom_left = [list(row)[:0:-1] for row in a]
   # mirror symmetry - make reversed copies of quad
   # drop the duplicate center elem, reverse
-  bottom = [list(bottom_right[i]) + list(a[i]) for i in range(len(a))]
+  bottom = [list(bottom_left[i]) + list(a[i]) for i in range(len(a))]
   if symmetry == "rot":
     # to get a rotated version, we need to reverse both rows and columns,
     # dropping the duplicate

--- a/verain/python/template2json.py
+++ b/verain/python/template2json.py
@@ -1,0 +1,46 @@
+# Export the simulator templates to a pure JSON object, so they
+# can be used by the 'vera' type in Simput to create a UI
+# automatically for these parameters.
+# See https://github.com/kitware/simput, types/vera/src/simModel.js
+from __future__ import absolute_import, division, print_function
+
+import os, json
+
+from Templates.SHIFT import SHIFT
+from Templates.MPACT import MPACT
+from Templates.COBRATF import COBRATF
+from Templates.INSILICO import INSILICO
+
+templateNames = {
+    # Simulator code config blocks
+    "SHIFT": SHIFT,
+    "COBRATF": COBRATF,
+    "INSILICO": INSILICO,
+    "MPACT": MPACT,
+}
+
+class FuncEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if callable(obj):
+            # replace functions by their name
+            return obj.__name__
+        elif type(obj) is slice:
+            # slice is a built-in, replace by string.
+            return str(obj)
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, obj)
+
+def parse( template, name ):
+    print( name )
+    return json.dumps(template, cls=FuncEncoder, indent=2)
+
+
+if __name__ == "__main__":
+    for key in templateNames:
+        result = parse(templateNames[key], key)
+        if result:
+            outFile = open(key + ".json", "w")
+            outFile.write(result)
+            outFile.close()
+
+


### PR DESCRIPTION
Add a script that takes the python templates for the simulation
config blocks, and outputs a json object representing the template.
It replaces functions by their name, so it is serializable.

Simput will use the json objects to automatically construct a UI for
setting all the parameters.

Fix a confusing variable name in Utils.py